### PR TITLE
Support for dynamic port env during ring server launch-up

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,14 +2,15 @@
   :description "FIXME: write description"
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [clj-time "0.9.0"] ; required due to bug in lein-ring
-                 [metosin/compojure-api "0.22.0"]]
+                 [metosin/compojure-api "0.22.0"]
+                 [ring-server "0.4.0"]
+                 [environ "1.0.1"]]
   :ring {:handler pigeon-backend.handler/app}
   :uberjar-name "server.jar"
   :profiles {:dev {:dependencies [[javax.servlet/servlet-api "2.5"]
                                   [cheshire "5.3.1"]
                                   [ring-mock "0.1.5"]
-                                  [midje "1.6.3"]
-                                  [ring-server "0.4.0"]]
+                                  [midje "1.6.3"]]
                    :plugins [[lein-ring "0.9.6"]
                              [lein-midje "3.1.3"]
                              [lein-cloverage "1.0.6"]]}}

--- a/src/pigeon_backend/handler.clj
+++ b/src/pigeon_backend/handler.clj
@@ -3,7 +3,8 @@
             [ring.util.http-response :refer :all]
             [schema.core :as s]
             [pigeon-backend.routes.hello :refer [hello-routes]]
-            [ring.server.standalone :as ring])
+            [ring.server.standalone :as ring]
+            [environ.core :refer [env]])
   (:gen-class))
 
 (defapi app
@@ -16,5 +17,13 @@
     :tags ["hello"]
     hello-routes))
 
+(defn handle-port-env [v]
+  (cond (and (string? v)
+             ((complement empty?) v))
+        (Integer/parseInt (env :port))
+        (integer? v)
+        v))
+
 (defn -main [& args]
-  (ring/serve app {:port 3000}))
+  (let [port (handle-port-env (env :port))]
+    (ring/serve app {:port port})))

--- a/src/pigeon_backend/handler.clj
+++ b/src/pigeon_backend/handler.clj
@@ -17,13 +17,11 @@
     :tags ["hello"]
     hello-routes))
 
-(defn handle-port-env [v]
-  (cond (and (string? v)
-             ((complement empty?) v))
-        (Integer/parseInt (env :port))
-        (integer? v)
-        v))
+(defn coerce-to-integer [v]
+  (if (string? v)
+    (Integer/parseInt v)
+    v))
 
 (defn -main [& args]
-  (let [port (handle-port-env (env :port))]
+  (let [port (coerce-to-integer (env :port))]
     (ring/serve app {:port port})))

--- a/test/pigeon_backend/handler_test.clj
+++ b/test/pigeon_backend/handler_test.clj
@@ -1,0 +1,9 @@
+(ns pigeon-backend.handler-test
+  (:require [midje.sweet :refer :all]
+            [pigeon-backend.handler :refer [coerce-to-integer ]]))
+
+(facts "Port env helper fn"
+  (fact "Numeric input"
+    (coerce-to-integer 3000) => 3000)
+  (fact "String input"
+    (coerce-to-integer "3000") => 3000))


### PR DESCRIPTION
Port environment can now be provided through a .lein-env file, through an environment variable or through Java system properties.