### PR TITLE
Add build command to Procfile.

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: java $JVM_OPTS -jar target/server.jar
+web: sh -c 'lein uberjar && java $JVM_OPTS -jar target/server.jar'


### PR DESCRIPTION
Fixes deploying on Heroku. Currently fails when target/server.jar does not exist.