### PR TITLE
Remove target directory from target path

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: java $JVM_OPTS -jar target/server.jar
+web: java $JVM_OPTS -jar server.jar


### PR DESCRIPTION
In Heroku, server.jar is located in the root directory (or a very educated guess using heroku to ssh into the application would have me believe).