### PR TITLE
Remove deployment process from CircleCI altogether.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,12 +9,3 @@ test:
     - lein with-profile +test cloverage
   post:
     - lein run -m pigeon-backend.coverage 86.03 95
-deployment:
-  production:
-    tag: /release-.*/
-    heroku:
-      appname: pigeon-backend
-  staging:
-    branch: master
-    heroku:
-      appname: pigeon-backend-staging


### PR DESCRIPTION
All deployments can be done via the GitHub API without any need for separate CircleCI push-deploy commands. Since Heroku (at the very least) does CI checks before automatic deployment, the separation of testing and deployment is not a problem.